### PR TITLE
Add category management and product deletion

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,6 +1,8 @@
 import { Routes } from '@angular/router';
 import { TableProductsComponent } from './pages/products/table-products/table-products.component';
 import { AddProductsComponent } from './pages/products/add-products/add-products.component';
+import { TableCategoriesComponent } from './pages/categories/table-categories/table-categories.component';
+import { AddCategoryComponent } from './pages/categories/add-category/add-category.component';
 
 export const routes: Routes = [
   {
@@ -17,6 +19,24 @@ export const routes: Routes = [
       {
         path: 'table',
         component: TableProductsComponent
+      }
+    ]
+  }
+  ,
+  {
+    path: 'categories',
+    children: [
+      {
+        path: 'add',
+        component: AddCategoryComponent
+      },
+      {
+        path: 'edit/:id',
+        component: AddCategoryComponent
+      },
+      {
+        path: 'table',
+        component: TableCategoriesComponent
       }
     ]
   }

--- a/src/app/material.module.ts
+++ b/src/app/material.module.ts
@@ -8,6 +8,7 @@ import { MatPaginatorModule } from '@angular/material/paginator';
 import { MatCardModule } from '@angular/material/card';
 import { MatButtonModule } from '@angular/material/button';
 import { MatInputModule } from '@angular/material/input';
+import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatMenuModule } from '@angular/material/menu';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MatDatepickerModule } from '@angular/material/datepicker';
@@ -57,6 +58,7 @@ import { FormsModule, NgModel, ReactiveFormsModule } from '@angular/forms';
     MatCardModule,
     MatButtonModule,
     MatInputModule,
+    MatFormFieldModule,
     MatMenuModule,
     MatSlideToggleModule,
     MatDatepickerModule,

--- a/src/app/models/Category.model.ts
+++ b/src/app/models/Category.model.ts
@@ -1,0 +1,4 @@
+export interface Category {
+  category_id: number;
+  name: string;
+}

--- a/src/app/pages/categories/add-category/add-category.component.html
+++ b/src/app/pages/categories/add-category/add-category.component.html
@@ -1,1 +1,10 @@
-<p>add-category works!</p>
+<form [formGroup]="form" (ngSubmit)="submit()" class="category-form">
+  <mat-form-field appearance="outline">
+    <mat-label>Nombre</mat-label>
+    <input matInput formControlName="name" />
+  </mat-form-field>
+
+  <button mat-raised-button color="primary" type="submit">
+    {{ isEdit ? 'Actualizar' : 'Crear' }}
+  </button>
+</form>

--- a/src/app/pages/categories/add-category/add-category.component.scss
+++ b/src/app/pages/categories/add-category/add-category.component.scss
@@ -1,0 +1,6 @@
+.category-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  width: 300px;
+}

--- a/src/app/pages/categories/add-category/add-category.component.spec.ts
+++ b/src/app/pages/categories/add-category/add-category.component.spec.ts
@@ -1,5 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 import { AddCategoryComponent } from './add-category.component';
 
 describe('AddCategoryComponent', () => {
@@ -8,9 +9,8 @@ describe('AddCategoryComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [AddCategoryComponent]
-    })
-    .compileComponents();
+      imports: [AddCategoryComponent, HttpClientTestingModule, RouterTestingModule]
+    }).compileComponents();
 
     fixture = TestBed.createComponent(AddCategoryComponent);
     component = fixture.componentInstance;

--- a/src/app/pages/categories/add-category/add-category.component.ts
+++ b/src/app/pages/categories/add-category/add-category.component.ts
@@ -1,12 +1,60 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { ActivatedRoute, Router } from '@angular/router';
+import { MaterialModule } from '../../../material.module';
+import { CategoryService } from '../../../services/category.service';
 
 @Component({
   selector: 'app-add-category',
   standalone: true,
-  imports: [],
+  imports: [MaterialModule, ReactiveFormsModule],
   templateUrl: './add-category.component.html',
   styleUrl: './add-category.component.scss'
 })
-export class AddCategoryComponent {
+export class AddCategoryComponent implements OnInit {
+  form: FormGroup;
+  isEdit = false;
+  categoryId: number | null = null;
 
+  constructor(
+    private fb: FormBuilder,
+    private categoryService: CategoryService,
+    private route: ActivatedRoute,
+    private router: Router
+  ) {
+    this.form = this.fb.group({
+      name: ['', Validators.required]
+    });
+  }
+
+  ngOnInit(): void {
+    this.route.params.subscribe(params => {
+      if (params['id']) {
+        this.isEdit = true;
+        this.categoryId = +params['id'];
+        this.categoryService.getById(this.categoryId).subscribe(category => {
+          this.form.patchValue(category);
+        });
+      }
+    });
+  }
+
+  submit(): void {
+    if (this.form.invalid) {
+      return;
+    }
+    const data = this.form.value;
+
+    if (this.isEdit && this.categoryId) {
+      this.categoryService.update(this.categoryId, data).subscribe(() => {
+        alert('Categoría actualizada');
+        this.router.navigate(['/categories/table']);
+      });
+    } else {
+      this.categoryService.create(data).subscribe(() => {
+        alert('Categoría creada');
+        this.router.navigate(['/categories/table']);
+      });
+    }
+  }
 }

--- a/src/app/pages/categories/table-categories/table-categories.component.html
+++ b/src/app/pages/categories/table-categories/table-categories.component.html
@@ -1,1 +1,32 @@
-<p>table-categories works!</p>
+@if (!isLoading) {
+  <app-dynamic-filter [columns]="displayedColumns" [data]="categories" (filteredData)="categories = $event"></app-dynamic-filter>
+  <div class="table-container">
+    <table mat-table [dataSource]="categories" class="mat-elevation-z8">
+      <ng-container matColumnDef="category_id">
+        <th mat-header-cell *matHeaderCellDef> ID </th>
+        <td mat-cell *matCellDef="let category">{{ category.category_id }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="name">
+        <th mat-header-cell *matHeaderCellDef> Nombre </th>
+        <td mat-cell *matCellDef="let category">{{ category.name }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="actions">
+        <th mat-header-cell *matHeaderCellDef> Acciones </th>
+        <td mat-cell *matCellDef="let category">
+          <button mat-icon-button color="primary" [routerLink]="['/categories/edit', category.category_id]"><mat-icon>edit</mat-icon></button>
+          <button mat-icon-button color="warn" (click)="delete(category.category_id)"><mat-icon>delete</mat-icon></button>
+        </td>
+      </ng-container>
+
+      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+    </table>
+  </div>
+} @else {
+  <div class="loading">
+    <mat-spinner></mat-spinner>
+    <p>Cargando categorías...</p>
+  </div>
+}

--- a/src/app/pages/categories/table-categories/table-categories.component.scss
+++ b/src/app/pages/categories/table-categories/table-categories.component.scss
@@ -1,0 +1,10 @@
+.table-container {
+  overflow-x: auto;
+}
+
+.loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-top: 2rem;
+}

--- a/src/app/pages/categories/table-categories/table-categories.component.spec.ts
+++ b/src/app/pages/categories/table-categories/table-categories.component.spec.ts
@@ -1,5 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 import { TableCategoriesComponent } from './table-categories.component';
 
 describe('TableCategoriesComponent', () => {
@@ -8,9 +9,8 @@ describe('TableCategoriesComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [TableCategoriesComponent]
-    })
-    .compileComponents();
+      imports: [TableCategoriesComponent, HttpClientTestingModule, RouterTestingModule]
+    }).compileComponents();
 
     fixture = TestBed.createComponent(TableCategoriesComponent);
     component = fixture.componentInstance;

--- a/src/app/pages/categories/table-categories/table-categories.component.ts
+++ b/src/app/pages/categories/table-categories/table-categories.component.ts
@@ -1,12 +1,46 @@
 import { Component } from '@angular/core';
+import { Category } from '../../../models/Category.model';
+import { CategoryService } from '../../../services/category.service';
+import { MaterialModule } from '../../../material.module';
+import { DynamicFilterComponent } from '../../../shared/dynamic-filter/dynamic-filter.component';
+import { RouterModule } from '@angular/router';
 
 @Component({
   selector: 'app-table-categories',
   standalone: true,
-  imports: [],
+  imports: [MaterialModule, DynamicFilterComponent, RouterModule],
   templateUrl: './table-categories.component.html',
   styleUrl: './table-categories.component.scss'
 })
 export class TableCategoriesComponent {
+  displayedColumns: string[] = ['category_id', 'name', 'actions'];
+  categories: Category[] = [];
+  isLoading = true;
 
+  constructor(private categoryService: CategoryService) {}
+
+  ngOnInit(): void {
+    this.loadCategories();
+  }
+
+  loadCategories(): void {
+    this.categoryService.getAll().subscribe({
+      next: data => {
+        this.categories = data;
+        this.isLoading = false;
+      },
+      error: err => {
+        console.error('Error fetching categories', err);
+        this.isLoading = false;
+      }
+    });
+  }
+
+  delete(id: number): void {
+    if (confirm('¿Eliminar categoría?')) {
+      this.categoryService.delete(id).subscribe(() => {
+        this.categories = this.categories.filter(c => c.category_id !== id);
+      });
+    }
+  }
 }

--- a/src/app/pages/products/add-products/add-products.component.spec.ts
+++ b/src/app/pages/products/add-products/add-products.component.spec.ts
@@ -1,5 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 import { AddProductsComponent } from './add-products.component';
 
 describe('AddProductsComponent', () => {
@@ -8,9 +9,8 @@ describe('AddProductsComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [AddProductsComponent]
-    })
-    .compileComponents();
+      imports: [AddProductsComponent, HttpClientTestingModule, RouterTestingModule]
+    }).compileComponents();
 
     fixture = TestBed.createComponent(AddProductsComponent);
     component = fixture.componentInstance;

--- a/src/app/pages/products/table-products/table-products.component.html
+++ b/src/app/pages/products/table-products/table-products.component.html
@@ -43,7 +43,7 @@
       <th mat-header-cell *matHeaderCellDef> Acciones </th>
       <td mat-cell *matCellDef="let product">
         <button mat-icon-button color="primary" [routerLink]="['/products/edit', product.product_id]"><mat-icon>edit</mat-icon></button>
-        <button mat-icon-button color="warn"><mat-icon>delete</mat-icon></button>
+        <button mat-icon-button color="warn" (click)="delete(product.product_id)"><mat-icon>delete</mat-icon></button>
       </td>
     </ng-container>
 

--- a/src/app/pages/products/table-products/table-products.component.spec.ts
+++ b/src/app/pages/products/table-products/table-products.component.spec.ts
@@ -1,5 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 import { TableProductsComponent } from './table-products.component';
 
 describe('TableProductsComponent', () => {
@@ -8,9 +9,8 @@ describe('TableProductsComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [TableProductsComponent]
-    })
-    .compileComponents();
+      imports: [TableProductsComponent, HttpClientTestingModule, RouterTestingModule]
+    }).compileComponents();
 
     fixture = TestBed.createComponent(TableProductsComponent);
     component = fixture.componentInstance;

--- a/src/app/pages/products/table-products/table-products.component.ts
+++ b/src/app/pages/products/table-products/table-products.component.ts
@@ -32,4 +32,12 @@ export class TableProductsComponent {
       }
     });
   }
+
+  delete(id: number): void {
+    if (confirm('¿Eliminar producto?')) {
+      this.productService.delete(id).subscribe(() => {
+        this.products = this.products.filter(p => p.product_id !== id);
+      });
+    }
+  }
 }

--- a/src/app/services/category.service.ts
+++ b/src/app/services/category.service.ts
@@ -1,0 +1,33 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { Category } from '../models/Category.model';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class CategoryService {
+  private apiUrl = 'http://localhost:3000/api/categories';
+
+  constructor(private http: HttpClient) {}
+
+  getAll(): Observable<Category[]> {
+    return this.http.get<Category[]>(this.apiUrl);
+  }
+
+  getById(id: number): Observable<Category> {
+    return this.http.get<Category>(`${this.apiUrl}/${id}`);
+  }
+
+  create(category: Partial<Category>): Observable<Category> {
+    return this.http.post<Category>(this.apiUrl, category);
+  }
+
+  update(id: number, category: Partial<Category>): Observable<Category> {
+    return this.http.put<Category>(`${this.apiUrl}/${id}`, category);
+  }
+
+  delete(id: number): Observable<void> {
+    return this.http.delete<void>(`${this.apiUrl}/${id}`);
+  }
+}

--- a/src/app/services/product.service.ts
+++ b/src/app/services/product.service.ts
@@ -26,4 +26,8 @@ export class ProductService {
   update(id: number, product: Product): Observable<Product> {
     return this.http.put<Product>(`${this.apiUrl}/${id}`, product);
   }
+
+  delete(id: number): Observable<void> {
+    return this.http.delete<void>(`${this.apiUrl}/${id}`);
+  }
 }


### PR DESCRIPTION
## Summary
- add Category model and service
- implement Category create/edit form and list with filtering
- support deleting products and categories, add routes

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_689e33ffd154832e9f85bc44b4ae283d