### PR TITLE
feat: add responsive layout with sidenav

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,1 +1,45 @@
-<router-outlet></router-outlet>
+<mat-sidenav-container class="app-container">
+  <mat-sidenav
+    #sidenav
+    class="app-sidenav"
+    [mode]="isMobile ? 'over' : 'side'"
+    [opened]="!isMobile"
+  >
+    <mat-nav-list>
+      <a mat-list-item routerLink="/products/table" routerLinkActive="active">
+        <mat-icon>inventory_2</mat-icon>
+        <span>Productos</span>
+      </a>
+      <a mat-list-item routerLink="/categories/table" routerLinkActive="active">
+        <mat-icon>category</mat-icon>
+        <span>Categorías</span>
+      </a>
+      <a mat-list-item routerLink="/users/table" routerLinkActive="active">
+        <mat-icon>people</mat-icon>
+        <span>Usuarios</span>
+      </a>
+      <a mat-list-item routerLink="/orders/table" routerLinkActive="active">
+        <mat-icon>receipt_long</mat-icon>
+        <span>Órdenes</span>
+      </a>
+      <a mat-list-item routerLink="/order-details/table" routerLinkActive="active">
+        <mat-icon>receipt</mat-icon>
+        <span>Detalles de orden</span>
+      </a>
+    </mat-nav-list>
+  </mat-sidenav>
+
+  <mat-sidenav-content>
+    <mat-toolbar color="primary" class="app-toolbar">
+      <button mat-icon-button (click)="sidenav.toggle()">
+        <mat-icon>menu</mat-icon>
+      </button>
+      <span class="toolbar-title">{{ pageTitle }}</span>
+    </mat-toolbar>
+
+    <div class="page-content">
+      <router-outlet></router-outlet>
+    </div>
+  </mat-sidenav-content>
+</mat-sidenav-container>
+

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -1,0 +1,21 @@
+.app-container {
+  height: 100vh;
+}
+
+.app-sidenav {
+  width: 240px;
+}
+
+.app-toolbar {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+}
+
+.page-content {
+  padding: 16px;
+}
+
+.active {
+  background-color: rgba(0, 0, 0, 0.1);
+}

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -14,16 +14,10 @@ describe('AppComponent', () => {
     expect(app).toBeTruthy();
   });
 
-  it(`should have the 'front' title`, () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.componentInstance;
-    expect(app.title).toEqual('front');
-  });
-
-  it('should render title', () => {
+  it('should render the toolbar', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain('Hello, front');
+    expect(compiled.querySelector('mat-toolbar')).toBeTruthy();
   });
 });

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,14 +1,43 @@
-import { Component } from '@angular/core';
-import { RouterOutlet } from '@angular/router';
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute, NavigationEnd, Router, RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
 import { MaterialModule } from './material.module';
+import { BreakpointObserver, Breakpoints } from '@angular/cdk/layout';
+import { filter, map } from 'rxjs/operators';
 
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [RouterOutlet, MaterialModule],
+  imports: [RouterOutlet, RouterLink, RouterLinkActive, MaterialModule],
   templateUrl: './app.component.html',
   styleUrl: './app.component.scss'
 })
-export class AppComponent {
-  title = 'front';
+export class AppComponent implements OnInit {
+  pageTitle = '';
+  isMobile = false;
+
+  constructor(
+    private router: Router,
+    private activatedRoute: ActivatedRoute,
+    private breakpointObserver: BreakpointObserver
+  ) {}
+
+  ngOnInit(): void {
+    this.breakpointObserver
+      .observe([Breakpoints.Handset])
+      .subscribe(result => (this.isMobile = result.matches));
+
+    this.router.events
+      .pipe(
+        filter(event => event instanceof NavigationEnd),
+        map(() => this.activatedRoute),
+        map(route => {
+          while (route.firstChild) {
+            route = route.firstChild;
+          }
+          return route;
+        }),
+        map(route => route.snapshot.data['title'])
+      )
+      .subscribe(title => (this.pageTitle = title ?? ''));
+  }
 }

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -9,95 +9,106 @@ import { AddOrderComponent } from './pages/orders/add-order/add-order.component'
 import { TableOrderDetailsComponent } from './pages/order-details/table-order-details/table-order-details.component';
 import { AddOrderDetailComponent } from './pages/order-details/add-order-detail/add-order-detail.component';
 import { TableOrdersComponent } from './pages/orders/table-orders/table-orders.component';
-import { AddOrderComponent } from './pages/orders/add-order/add-order.component';
 
 export const routes: Routes = [
+  { path: '', redirectTo: 'products/table', pathMatch: 'full' },
   {
     path: 'products',
     children: [
       {
         path: 'add',
-        component: AddProductsComponent
+        component: AddProductsComponent,
+        data: { title: 'Agregar producto' }
       },
       {
         path: 'edit/:id',
-        component: AddProductsComponent
+        component: AddProductsComponent,
+        data: { title: 'Editar producto' }
       },
       {
         path: 'table',
-        component: TableProductsComponent
+        component: TableProductsComponent,
+        data: { title: 'Productos' }
       }
     ]
-  }
-  ,
+  },
   {
     path: 'categories',
     children: [
       {
         path: 'add',
-        component: AddCategoryComponent
+        component: AddCategoryComponent,
+        data: { title: 'Agregar categoría' }
       },
       {
         path: 'edit/:id',
-        component: AddCategoryComponent
+        component: AddCategoryComponent,
+        data: { title: 'Editar categoría' }
       },
       {
         path: 'table',
-        component: TableCategoriesComponent
+        component: TableCategoriesComponent,
+        data: { title: 'Categorías' }
       }
     ]
-  }
-  ,
+  },
   {
     path: 'users',
     children: [
       {
         path: 'add',
-        component: AddUserComponent
+        component: AddUserComponent,
+        data: { title: 'Agregar usuario' }
       },
       {
         path: 'edit/:id',
-        component: AddUserComponent
+        component: AddUserComponent,
+        data: { title: 'Editar usuario' }
       },
       {
         path: 'table',
-        component: TableUsersComponent
+        component: TableUsersComponent,
+        data: { title: 'Usuarios' }
       }
     ]
-  }
-  ,
+  },
   {
     path: 'orders',
     children: [
       {
         path: 'add',
-        component: AddOrderComponent
+        component: AddOrderComponent,
+        data: { title: 'Agregar orden' }
       },
       {
         path: 'edit/:id',
-        component: AddOrderComponent
+        component: AddOrderComponent,
+        data: { title: 'Editar orden' }
       },
       {
         path: 'table',
-        component: TableOrdersComponent
+        component: TableOrdersComponent,
+        data: { title: 'Órdenes' }
       }
     ]
-  }
-  ,
+  },
   {
     path: 'order-details',
     children: [
       {
         path: 'add',
-        component: AddOrderDetailComponent
+        component: AddOrderDetailComponent,
+        data: { title: 'Agregar detalle de orden' }
       },
       {
         path: 'edit/:id',
-        component: AddOrderDetailComponent
+        component: AddOrderDetailComponent,
+        data: { title: 'Editar detalle de orden' }
       },
       {
         path: 'table',
-        component: TableOrderDetailsComponent
+        component: TableOrderDetailsComponent,
+        data: { title: 'Detalles de orden' }
       }
     ]
   }


### PR DESCRIPTION
## Summary
- add Angular Material toolbar and side navigation with icons
- load page titles from route data and adjust layout for mobile
- wire up route metadata and update tests

## Testing
- `npm run build -- --configuration=development`
- `npm test -- --watch=false` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_689e5779b808832e85c098dba977587d