### PR TITLE
feat: add CRUD for activity logs, printers, tables and tickets

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -26,6 +26,22 @@
         <mat-icon>receipt</mat-icon>
         <span>Detalles de orden</span>
       </a>
+          <a mat-list-item routerLink="/activity-logs/table" routerLinkActive="active">
+        <mat-icon>history</mat-icon>
+        <span>Logs de actividad</span>
+      </a>
+      <a mat-list-item routerLink="/printers/table" routerLinkActive="active">
+        <mat-icon>print</mat-icon>
+        <span>Impresoras</span>
+      </a>
+      <a mat-list-item routerLink="/restaurant-tables/table" routerLinkActive="active">
+        <mat-icon>table_bar</mat-icon>
+        <span>Mesas</span>
+      </a>
+      <a mat-list-item routerLink="/tickets/table" routerLinkActive="active">
+        <mat-icon>confirmation_number</mat-icon>
+        <span>Tickets</span>
+      </a>
     </mat-nav-list>
   </mat-sidenav>
 

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -9,6 +9,14 @@ import { AddOrderComponent } from './pages/orders/add-order/add-order.component'
 import { TableOrderDetailsComponent } from './pages/order-details/table-order-details/table-order-details.component';
 import { AddOrderDetailComponent } from './pages/order-details/add-order-detail/add-order-detail.component';
 import { TableOrdersComponent } from './pages/orders/table-orders/table-orders.component';
+import { AddActivityLogComponent } from './pages/activity-logs/add-activity-log/add-activity-log.component';
+import { TableActivityLogsComponent } from './pages/activity-logs/table-activity-logs/table-activity-logs.component';
+import { AddPrinterComponent } from './pages/printers/add-printer/add-printer.component';
+import { TablePrintersComponent } from './pages/printers/table-printers/table-printers.component';
+import { AddRestaurantTableComponent } from './pages/restaurant-tables/add-restaurant-table/add-restaurant-table.component';
+import { TableRestaurantTablesComponent } from './pages/restaurant-tables/table-restaurant-tables/table-restaurant-tables.component';
+import { AddTicketComponent } from './pages/tickets/add-ticket/add-ticket.component';
+import { TableTicketsComponent } from './pages/tickets/table-tickets/table-tickets.component';
 
 export const routes: Routes = [
   { path: '', redirectTo: 'products/table', pathMatch: 'full' },
@@ -109,6 +117,86 @@ export const routes: Routes = [
         path: 'table',
         component: TableOrderDetailsComponent,
         data: { title: 'Detalles de orden' }
+      }
+    ]
+  },
+  {
+    path: 'activity-logs',
+    children: [
+      {
+        path: 'add',
+        component: AddActivityLogComponent,
+        data: { title: 'Agregar log' }
+      },
+      {
+        path: 'edit/:id',
+        component: AddActivityLogComponent,
+        data: { title: 'Editar log' }
+      },
+      {
+        path: 'table',
+        component: TableActivityLogsComponent,
+        data: { title: 'Logs de actividad' }
+      }
+    ]
+  },
+  {
+    path: 'printers',
+    children: [
+      {
+        path: 'add',
+        component: AddPrinterComponent,
+        data: { title: 'Agregar impresora' }
+      },
+      {
+        path: 'edit/:id',
+        component: AddPrinterComponent,
+        data: { title: 'Editar impresora' }
+      },
+      {
+        path: 'table',
+        component: TablePrintersComponent,
+        data: { title: 'Impresoras' }
+      }
+    ]
+  },
+  {
+    path: 'restaurant-tables',
+    children: [
+      {
+        path: 'add',
+        component: AddRestaurantTableComponent,
+        data: { title: 'Agregar mesa' }
+      },
+      {
+        path: 'edit/:id',
+        component: AddRestaurantTableComponent,
+        data: { title: 'Editar mesa' }
+      },
+      {
+        path: 'table',
+        component: TableRestaurantTablesComponent,
+        data: { title: 'Mesas' }
+      }
+    ]
+  },
+  {
+    path: 'tickets',
+    children: [
+      {
+        path: 'add',
+        component: AddTicketComponent,
+        data: { title: 'Agregar ticket' }
+      },
+      {
+        path: 'edit/:id',
+        component: AddTicketComponent,
+        data: { title: 'Editar ticket' }
+      },
+      {
+        path: 'table',
+        component: TableTicketsComponent,
+        data: { title: 'Tickets' }
       }
     ]
   }

--- a/src/app/pages/activity-logs/add-activity-log/add-activity-log.component.html
+++ b/src/app/pages/activity-logs/add-activity-log/add-activity-log.component.html
@@ -1,0 +1,28 @@
+<div class="form-container">
+  <h2>{{ isEdit ? 'Editar Log' : 'Crear Log' }}</h2>
+
+  <form [formGroup]="form" (ngSubmit)="submit()">
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>ID Usuario</mat-label>
+      <input matInput type="number" formControlName="user_id">
+      <mat-error *ngIf="form.get('user_id')?.invalid">Requerido</mat-error>
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Acción</mat-label>
+      <input matInput formControlName="action">
+      <mat-error *ngIf="form.get('action')?.invalid">Requerido</mat-error>
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Fecha</mat-label>
+      <input matInput formControlName="log_time">
+      <mat-error *ngIf="form.get('log_time')?.invalid">Requerido</mat-error>
+    </mat-form-field>
+
+    <div class="actions">
+      <button mat-raised-button color="primary" type="submit">{{ isEdit ? 'Actualizar' : 'Crear' }}</button>
+      <button mat-raised-button color="warn" routerLink="/activity-logs/table" type="button">Cancelar</button>
+    </div>
+  </form>
+</div>

--- a/src/app/pages/activity-logs/add-activity-log/add-activity-log.component.scss
+++ b/src/app/pages/activity-logs/add-activity-log/add-activity-log.component.scss
@@ -1,0 +1,19 @@
+.form-container {
+  max-width: 600px;
+  margin: 2rem auto;
+  padding: 2rem;
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+}
+
+.full-width {
+  width: 100%;
+  margin-bottom: 1rem;
+}
+
+.actions {
+  display: flex;
+  gap: 1rem;
+  margin-top: 1.5rem;
+}

--- a/src/app/pages/activity-logs/add-activity-log/add-activity-log.component.spec.ts
+++ b/src/app/pages/activity-logs/add-activity-log/add-activity-log.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { AddActivityLogComponent } from './add-activity-log.component';
+
+describe('AddActivityLogComponent', () => {
+  let component: AddActivityLogComponent;
+  let fixture: ComponentFixture<AddActivityLogComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [AddActivityLogComponent, HttpClientTestingModule, RouterTestingModule]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AddActivityLogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/pages/activity-logs/add-activity-log/add-activity-log.component.ts
+++ b/src/app/pages/activity-logs/add-activity-log/add-activity-log.component.ts
@@ -1,0 +1,63 @@
+import { Component, OnInit } from '@angular/core';
+import { FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
+import { ActivatedRoute, Router } from '@angular/router';
+import { MaterialModule } from '../../../material.module';
+import { ActivityLogService } from '../../../services/activity-log.service';
+
+@Component({
+  selector: 'app-add-activity-log',
+  standalone: true,
+  imports: [MaterialModule, ReactiveFormsModule],
+  templateUrl: './add-activity-log.component.html',
+  styleUrl: './add-activity-log.component.scss'
+})
+export class AddActivityLogComponent implements OnInit {
+  form: FormGroup;
+  isEdit = false;
+  logId: number | null = null;
+
+  constructor(
+    private fb: FormBuilder,
+    private activityLogService: ActivityLogService,
+    private route: ActivatedRoute,
+    private router: Router
+  ) {
+    this.form = this.fb.group({
+      user_id: ['', Validators.required],
+      action: ['', Validators.required],
+      log_time: ['', Validators.required]
+    });
+  }
+
+  ngOnInit(): void {
+    this.route.params.subscribe(params => {
+      if (params['id']) {
+        this.isEdit = true;
+        this.logId = +params['id'];
+        this.activityLogService.getById(this.logId).subscribe(log => {
+          this.form.patchValue(log);
+        });
+      }
+    });
+  }
+
+  submit(): void {
+    if (this.form.invalid) {
+      return;
+    }
+    const data = this.form.value;
+
+    if (this.isEdit && this.logId) {
+      this.activityLogService.update(this.logId, data).subscribe(() => {
+        alert('Log actualizado');
+        this.router.navigate(['/activity-logs/table']);
+      });
+    } else {
+      this.activityLogService.create(data).subscribe(() => {
+        alert('Log creado');
+        this.router.navigate(['/activity-logs/table']);
+      });
+    }
+  }
+}
+

--- a/src/app/pages/activity-logs/table-activity-logs/table-activity-logs.component.html
+++ b/src/app/pages/activity-logs/table-activity-logs/table-activity-logs.component.html
@@ -1,0 +1,45 @@
+@if (!isLoading) {
+  <app-dynamic-filter [columns]="displayedColumns" [data]="logs" (filteredData)="logs = $event"></app-dynamic-filter>
+  <div class="table-container">
+    <table mat-table [dataSource]="logs" class="mat-elevation-z8">
+      <ng-container matColumnDef="log_id">
+        <th mat-header-cell *matHeaderCellDef> ID </th>
+        <td mat-cell *matCellDef="let log">{{ log.log_id }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="user_id">
+        <th mat-header-cell *matHeaderCellDef> Usuario </th>
+        <td mat-cell *matCellDef="let log">{{ log.user_id }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="action">
+        <th mat-header-cell *matHeaderCellDef> Acción </th>
+        <td mat-cell *matCellDef="let log">{{ log.action }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="log_time">
+        <th mat-header-cell *matHeaderCellDef> Fecha </th>
+        <td mat-cell *matCellDef="let log">{{ log.log_time }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="actions">
+        <th mat-header-cell *matHeaderCellDef> Acciones </th>
+        <td mat-cell *matCellDef="let log">
+          <button mat-icon-button color="primary" [routerLink]="['/activity-logs/edit', log.log_id]"><mat-icon>edit</mat-icon></button>
+          <button mat-icon-button color="warn" (click)="delete(log.log_id)"><mat-icon>delete</mat-icon></button>
+        </td>
+      </ng-container>
+
+      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+    </table>
+  </div>
+}
+@else {
+  <ng-template #loading>
+    <div class="loading">
+      <mat-spinner></mat-spinner>
+      <p>Cargando logs...</p>
+    </div>
+  </ng-template>
+}

--- a/src/app/pages/activity-logs/table-activity-logs/table-activity-logs.component.scss
+++ b/src/app/pages/activity-logs/table-activity-logs/table-activity-logs.component.scss
@@ -1,0 +1,20 @@
+.table-container {
+  max-width: 1000px;
+  margin: 20px auto;
+  padding: 15px;
+}
+
+mat-header-cell {
+  font-weight: bold;
+}
+
+mat-icon {
+  vertical-align: middle;
+}
+
+.loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-top: 50px;
+}

--- a/src/app/pages/activity-logs/table-activity-logs/table-activity-logs.component.spec.ts
+++ b/src/app/pages/activity-logs/table-activity-logs/table-activity-logs.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { TableActivityLogsComponent } from './table-activity-logs.component';
+
+describe('TableActivityLogsComponent', () => {
+  let component: TableActivityLogsComponent;
+  let fixture: ComponentFixture<TableActivityLogsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TableActivityLogsComponent, HttpClientTestingModule, RouterTestingModule]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TableActivityLogsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/pages/activity-logs/table-activity-logs/table-activity-logs.component.ts
+++ b/src/app/pages/activity-logs/table-activity-logs/table-activity-logs.component.ts
@@ -1,0 +1,46 @@
+import { Component } from '@angular/core';
+import { ActivityLog } from '../../../models/ActivityLog.model';
+import { ActivityLogService } from '../../../services/activity-log.service';
+import { MaterialModule } from '../../../material.module';
+import { DynamicFilterComponent } from '../../../shared/dynamic-filter/dynamic-filter.component';
+import { RouterModule } from '@angular/router';
+
+@Component({
+  selector: 'app-table-activity-logs',
+  standalone: true,
+  imports: [MaterialModule, DynamicFilterComponent, RouterModule],
+  templateUrl: './table-activity-logs.component.html',
+  styleUrl: './table-activity-logs.component.scss'
+})
+export class TableActivityLogsComponent {
+  displayedColumns: string[] = ['log_id', 'user_id', 'action', 'log_time', 'actions'];
+  logs: ActivityLog[] = [];
+  isLoading = true;
+
+  constructor(private activityLogService: ActivityLogService) {}
+
+  ngOnInit(): void {
+    this.loadLogs();
+  }
+
+  loadLogs(): void {
+    this.activityLogService.getAll().subscribe({
+      next: data => {
+        this.logs = data;
+        this.isLoading = false;
+      },
+      error: err => {
+        console.error('Error fetching logs', err);
+        this.isLoading = false;
+      }
+    });
+  }
+
+  delete(id: number): void {
+    if (confirm('¿Eliminar log?')) {
+      this.activityLogService.delete(id).subscribe(() => {
+        this.logs = this.logs.filter(l => l.log_id !== id);
+      });
+    }
+  }
+}

--- a/src/app/pages/printers/add-printer/add-printer.component.html
+++ b/src/app/pages/printers/add-printer/add-printer.component.html
@@ -1,0 +1,30 @@
+<div class="form-container">
+  <h2>{{ isEdit ? 'Editar Impresora' : 'Crear Impresora' }}</h2>
+
+  <form [formGroup]="form" (ngSubmit)="submit()">
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Nombre</mat-label>
+      <input matInput formControlName="name">
+      <mat-error *ngIf="form.get('name')?.invalid">Requerido</mat-error>
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Ubicación</mat-label>
+      <mat-select formControlName="location">
+        <mat-option *ngFor="let loc of locations" [value]="loc.value">{{ loc.viewValue }}</mat-option>
+      </mat-select>
+      <mat-error *ngIf="form.get('location')?.invalid">Requerido</mat-error>
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>IP</mat-label>
+      <input matInput formControlName="ip_address">
+      <mat-error *ngIf="form.get('ip_address')?.invalid">Requerido</mat-error>
+    </mat-form-field>
+
+    <div class="actions">
+      <button mat-raised-button color="primary" type="submit">{{ isEdit ? 'Actualizar' : 'Crear' }}</button>
+      <button mat-raised-button color="warn" routerLink="/printers/table" type="button">Cancelar</button>
+    </div>
+  </form>
+</div>

--- a/src/app/pages/printers/add-printer/add-printer.component.scss
+++ b/src/app/pages/printers/add-printer/add-printer.component.scss
@@ -1,0 +1,19 @@
+.form-container {
+  max-width: 600px;
+  margin: 2rem auto;
+  padding: 2rem;
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+}
+
+.full-width {
+  width: 100%;
+  margin-bottom: 1rem;
+}
+
+.actions {
+  display: flex;
+  gap: 1rem;
+  margin-top: 1.5rem;
+}

--- a/src/app/pages/printers/add-printer/add-printer.component.spec.ts
+++ b/src/app/pages/printers/add-printer/add-printer.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { AddPrinterComponent } from './add-printer.component';
+
+describe('AddPrinterComponent', () => {
+  let component: AddPrinterComponent;
+  let fixture: ComponentFixture<AddPrinterComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [AddPrinterComponent, HttpClientTestingModule, RouterTestingModule]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AddPrinterComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/pages/printers/add-printer/add-printer.component.ts
+++ b/src/app/pages/printers/add-printer/add-printer.component.ts
@@ -1,0 +1,66 @@
+import { Component, OnInit } from '@angular/core';
+import { FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
+import { ActivatedRoute, Router } from '@angular/router';
+import { MaterialModule } from '../../../material.module';
+import { PrinterService } from '../../../services/printer.service';
+
+@Component({
+  selector: 'app-add-printer',
+  standalone: true,
+  imports: [MaterialModule, ReactiveFormsModule],
+  templateUrl: './add-printer.component.html',
+  styleUrl: './add-printer.component.scss'
+})
+export class AddPrinterComponent implements OnInit {
+  form: FormGroup;
+  isEdit = false;
+  printerId: number | null = null;
+  locations = [
+    { value: 'kitchen', viewValue: 'Cocina' },
+    { value: 'cashier', viewValue: 'Caja' }
+  ];
+
+  constructor(
+    private fb: FormBuilder,
+    private printerService: PrinterService,
+    private route: ActivatedRoute,
+    private router: Router
+  ) {
+    this.form = this.fb.group({
+      name: ['', Validators.required],
+      location: ['', Validators.required],
+      ip_address: ['', Validators.required]
+    });
+  }
+
+  ngOnInit(): void {
+    this.route.params.subscribe(params => {
+      if (params['id']) {
+        this.isEdit = true;
+        this.printerId = +params['id'];
+        this.printerService.getById(this.printerId).subscribe(printer => {
+          this.form.patchValue(printer);
+        });
+      }
+    });
+  }
+
+  submit(): void {
+    if (this.form.invalid) {
+      return;
+    }
+    const data = this.form.value;
+
+    if (this.isEdit && this.printerId) {
+      this.printerService.update(this.printerId, data).subscribe(() => {
+        alert('Impresora actualizada');
+        this.router.navigate(['/printers/table']);
+      });
+    } else {
+      this.printerService.create(data).subscribe(() => {
+        alert('Impresora creada');
+        this.router.navigate(['/printers/table']);
+      });
+    }
+  }
+}

--- a/src/app/pages/printers/table-printers/table-printers.component.html
+++ b/src/app/pages/printers/table-printers/table-printers.component.html
@@ -1,0 +1,45 @@
+@if (!isLoading) {
+  <app-dynamic-filter [columns]="displayedColumns" [data]="printers" (filteredData)="printers = $event"></app-dynamic-filter>
+  <div class="table-container">
+    <table mat-table [dataSource]="printers" class="mat-elevation-z8">
+      <ng-container matColumnDef="printer_id">
+        <th mat-header-cell *matHeaderCellDef> ID </th>
+        <td mat-cell *matCellDef="let printer">{{ printer.printer_id }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="name">
+        <th mat-header-cell *matHeaderCellDef> Nombre </th>
+        <td mat-cell *matCellDef="let printer">{{ printer.name }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="location">
+        <th mat-header-cell *matHeaderCellDef> Ubicación </th>
+        <td mat-cell *matCellDef="let printer">{{ printer.location }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="ip_address">
+        <th mat-header-cell *matHeaderCellDef> IP </th>
+        <td mat-cell *matCellDef="let printer">{{ printer.ip_address }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="actions">
+        <th mat-header-cell *matHeaderCellDef> Acciones </th>
+        <td mat-cell *matCellDef="let printer">
+          <button mat-icon-button color="primary" [routerLink]="['/printers/edit', printer.printer_id]"><mat-icon>edit</mat-icon></button>
+          <button mat-icon-button color="warn" (click)="delete(printer.printer_id)"><mat-icon>delete</mat-icon></button>
+        </td>
+      </ng-container>
+
+      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+    </table>
+  </div>
+}
+@else {
+  <ng-template #loading>
+    <div class="loading">
+      <mat-spinner></mat-spinner>
+      <p>Cargando impresoras...</p>
+    </div>
+  </ng-template>
+}

--- a/src/app/pages/printers/table-printers/table-printers.component.scss
+++ b/src/app/pages/printers/table-printers/table-printers.component.scss
@@ -1,0 +1,20 @@
+.table-container {
+  max-width: 1000px;
+  margin: 20px auto;
+  padding: 15px;
+}
+
+mat-header-cell {
+  font-weight: bold;
+}
+
+mat-icon {
+  vertical-align: middle;
+}
+
+.loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-top: 50px;
+}

--- a/src/app/pages/printers/table-printers/table-printers.component.spec.ts
+++ b/src/app/pages/printers/table-printers/table-printers.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { TablePrintersComponent } from './table-printers.component';
+
+describe('TablePrintersComponent', () => {
+  let component: TablePrintersComponent;
+  let fixture: ComponentFixture<TablePrintersComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TablePrintersComponent, HttpClientTestingModule, RouterTestingModule]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TablePrintersComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/pages/printers/table-printers/table-printers.component.ts
+++ b/src/app/pages/printers/table-printers/table-printers.component.ts
@@ -1,0 +1,46 @@
+import { Component } from '@angular/core';
+import { Printer } from '../../../models/Printer.model';
+import { PrinterService } from '../../../services/printer.service';
+import { MaterialModule } from '../../../material.module';
+import { DynamicFilterComponent } from '../../../shared/dynamic-filter/dynamic-filter.component';
+import { RouterModule } from '@angular/router';
+
+@Component({
+  selector: 'app-table-printers',
+  standalone: true,
+  imports: [MaterialModule, DynamicFilterComponent, RouterModule],
+  templateUrl: './table-printers.component.html',
+  styleUrl: './table-printers.component.scss'
+})
+export class TablePrintersComponent {
+  displayedColumns: string[] = ['printer_id', 'name', 'location', 'ip_address', 'actions'];
+  printers: Printer[] = [];
+  isLoading = true;
+
+  constructor(private printerService: PrinterService) {}
+
+  ngOnInit(): void {
+    this.loadPrinters();
+  }
+
+  loadPrinters(): void {
+    this.printerService.getAll().subscribe({
+      next: data => {
+        this.printers = data;
+        this.isLoading = false;
+      },
+      error: err => {
+        console.error('Error fetching printers', err);
+        this.isLoading = false;
+      }
+    });
+  }
+
+  delete(id: number): void {
+    if (confirm('¿Eliminar impresora?')) {
+      this.printerService.delete(id).subscribe(() => {
+        this.printers = this.printers.filter(p => p.printer_id !== id);
+      });
+    }
+  }
+}

--- a/src/app/pages/restaurant-tables/add-restaurant-table/add-restaurant-table.component.html
+++ b/src/app/pages/restaurant-tables/add-restaurant-table/add-restaurant-table.component.html
@@ -1,0 +1,29 @@
+<div class="form-container">
+  <h2>{{ isEdit ? 'Editar Mesa' : 'Crear Mesa' }}</h2>
+
+  <form [formGroup]="form" (ngSubmit)="submit()">
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Número de mesa</mat-label>
+      <input matInput type="number" formControlName="table_number">
+      <mat-error *ngIf="form.get('table_number')?.invalid">Requerido</mat-error>
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Estado</mat-label>
+      <mat-select formControlName="status">
+        <mat-option *ngFor="let st of statuses" [value]="st.value">{{ st.viewValue }}</mat-option>
+      </mat-select>
+      <mat-error *ngIf="form.get('status')?.invalid">Requerido</mat-error>
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Sección</mat-label>
+      <input matInput formControlName="section">
+    </mat-form-field>
+
+    <div class="actions">
+      <button mat-raised-button color="primary" type="submit">{{ isEdit ? 'Actualizar' : 'Crear' }}</button>
+      <button mat-raised-button color="warn" routerLink="/restaurant-tables/table" type="button">Cancelar</button>
+    </div>
+  </form>
+</div>

--- a/src/app/pages/restaurant-tables/add-restaurant-table/add-restaurant-table.component.scss
+++ b/src/app/pages/restaurant-tables/add-restaurant-table/add-restaurant-table.component.scss
@@ -1,0 +1,19 @@
+.form-container {
+  max-width: 600px;
+  margin: 2rem auto;
+  padding: 2rem;
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+}
+
+.full-width {
+  width: 100%;
+  margin-bottom: 1rem;
+}
+
+.actions {
+  display: flex;
+  gap: 1rem;
+  margin-top: 1.5rem;
+}

--- a/src/app/pages/restaurant-tables/add-restaurant-table/add-restaurant-table.component.spec.ts
+++ b/src/app/pages/restaurant-tables/add-restaurant-table/add-restaurant-table.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { AddRestaurantTableComponent } from './add-restaurant-table.component';
+
+describe('AddRestaurantTableComponent', () => {
+  let component: AddRestaurantTableComponent;
+  let fixture: ComponentFixture<AddRestaurantTableComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [AddRestaurantTableComponent, HttpClientTestingModule, RouterTestingModule]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AddRestaurantTableComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/pages/restaurant-tables/add-restaurant-table/add-restaurant-table.component.ts
+++ b/src/app/pages/restaurant-tables/add-restaurant-table/add-restaurant-table.component.ts
@@ -1,0 +1,68 @@
+import { Component, OnInit } from '@angular/core';
+import { FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
+import { ActivatedRoute, Router } from '@angular/router';
+import { MaterialModule } from '../../../material.module';
+import { RestaurantTableService } from '../../../services/restaurant-table.service';
+
+@Component({
+  selector: 'app-add-restaurant-table',
+  standalone: true,
+  imports: [MaterialModule, ReactiveFormsModule],
+  templateUrl: './add-restaurant-table.component.html',
+  styleUrl: './add-restaurant-table.component.scss'
+})
+export class AddRestaurantTableComponent implements OnInit {
+  form: FormGroup;
+  isEdit = false;
+  tableId: number | null = null;
+  statuses = [
+    { value: 'free', viewValue: 'Libre' },
+    { value: 'occupied', viewValue: 'Ocupada' },
+    { value: 'reserved', viewValue: 'Reservada' },
+    { value: 'waiting_payment', viewValue: 'Esperando pago' }
+  ];
+
+  constructor(
+    private fb: FormBuilder,
+    private tableService: RestaurantTableService,
+    private route: ActivatedRoute,
+    private router: Router
+  ) {
+    this.form = this.fb.group({
+      table_number: ['', Validators.required],
+      status: ['free', Validators.required],
+      section: ['']
+    });
+  }
+
+  ngOnInit(): void {
+    this.route.params.subscribe(params => {
+      if (params['id']) {
+        this.isEdit = true;
+        this.tableId = +params['id'];
+        this.tableService.getById(this.tableId).subscribe(table => {
+          this.form.patchValue(table);
+        });
+      }
+    });
+  }
+
+  submit(): void {
+    if (this.form.invalid) {
+      return;
+    }
+    const data = this.form.value;
+
+    if (this.isEdit && this.tableId) {
+      this.tableService.update(this.tableId, data).subscribe(() => {
+        alert('Mesa actualizada');
+        this.router.navigate(['/restaurant-tables/table']);
+      });
+    } else {
+      this.tableService.create(data).subscribe(() => {
+        alert('Mesa creada');
+        this.router.navigate(['/restaurant-tables/table']);
+      });
+    }
+  }
+}

--- a/src/app/pages/restaurant-tables/table-restaurant-tables/table-restaurant-tables.component.html
+++ b/src/app/pages/restaurant-tables/table-restaurant-tables/table-restaurant-tables.component.html
@@ -1,0 +1,45 @@
+@if (!isLoading) {
+  <app-dynamic-filter [columns]="displayedColumns" [data]="tables" (filteredData)="tables = $event"></app-dynamic-filter>
+  <div class="table-container">
+    <table mat-table [dataSource]="tables" class="mat-elevation-z8">
+      <ng-container matColumnDef="table_id">
+        <th mat-header-cell *matHeaderCellDef> ID </th>
+        <td mat-cell *matCellDef="let table">{{ table.table_id }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="table_number">
+        <th mat-header-cell *matHeaderCellDef> Número </th>
+        <td mat-cell *matCellDef="let table">{{ table.table_number }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="status">
+        <th mat-header-cell *matHeaderCellDef> Estado </th>
+        <td mat-cell *matCellDef="let table">{{ table.status }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="section">
+        <th mat-header-cell *matHeaderCellDef> Sección </th>
+        <td mat-cell *matCellDef="let table">{{ table.section }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="actions">
+        <th mat-header-cell *matHeaderCellDef> Acciones </th>
+        <td mat-cell *matCellDef="let table">
+          <button mat-icon-button color="primary" [routerLink]="['/restaurant-tables/edit', table.table_id]"><mat-icon>edit</mat-icon></button>
+          <button mat-icon-button color="warn" (click)="delete(table.table_id)"><mat-icon>delete</mat-icon></button>
+        </td>
+      </ng-container>
+
+      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+    </table>
+  </div>
+}
+@else {
+  <ng-template #loading>
+    <div class="loading">
+      <mat-spinner></mat-spinner>
+      <p>Cargando mesas...</p>
+    </div>
+  </ng-template>
+}

--- a/src/app/pages/restaurant-tables/table-restaurant-tables/table-restaurant-tables.component.scss
+++ b/src/app/pages/restaurant-tables/table-restaurant-tables/table-restaurant-tables.component.scss
@@ -1,0 +1,20 @@
+.table-container {
+  max-width: 1000px;
+  margin: 20px auto;
+  padding: 15px;
+}
+
+mat-header-cell {
+  font-weight: bold;
+}
+
+mat-icon {
+  vertical-align: middle;
+}
+
+.loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-top: 50px;
+}

--- a/src/app/pages/restaurant-tables/table-restaurant-tables/table-restaurant-tables.component.spec.ts
+++ b/src/app/pages/restaurant-tables/table-restaurant-tables/table-restaurant-tables.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { TableRestaurantTablesComponent } from './table-restaurant-tables.component';
+
+describe('TableRestaurantTablesComponent', () => {
+  let component: TableRestaurantTablesComponent;
+  let fixture: ComponentFixture<TableRestaurantTablesComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TableRestaurantTablesComponent, HttpClientTestingModule, RouterTestingModule]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TableRestaurantTablesComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/pages/restaurant-tables/table-restaurant-tables/table-restaurant-tables.component.ts
+++ b/src/app/pages/restaurant-tables/table-restaurant-tables/table-restaurant-tables.component.ts
@@ -1,0 +1,46 @@
+import { Component } from '@angular/core';
+import { RestaurantTable } from '../../../models/RestaurantTable.model';
+import { RestaurantTableService } from '../../../services/restaurant-table.service';
+import { MaterialModule } from '../../../material.module';
+import { DynamicFilterComponent } from '../../../shared/dynamic-filter/dynamic-filter.component';
+import { RouterModule } from '@angular/router';
+
+@Component({
+  selector: 'app-table-restaurant-tables',
+  standalone: true,
+  imports: [MaterialModule, DynamicFilterComponent, RouterModule],
+  templateUrl: './table-restaurant-tables.component.html',
+  styleUrl: './table-restaurant-tables.component.scss'
+})
+export class TableRestaurantTablesComponent {
+  displayedColumns: string[] = ['table_id', 'table_number', 'status', 'section', 'actions'];
+  tables: RestaurantTable[] = [];
+  isLoading = true;
+
+  constructor(private tableService: RestaurantTableService) {}
+
+  ngOnInit(): void {
+    this.loadTables();
+  }
+
+  loadTables(): void {
+    this.tableService.getAll().subscribe({
+      next: data => {
+        this.tables = data;
+        this.isLoading = false;
+      },
+      error: err => {
+        console.error('Error fetching tables', err);
+        this.isLoading = false;
+      }
+    });
+  }
+
+  delete(id: number): void {
+    if (confirm('¿Eliminar mesa?')) {
+      this.tableService.delete(id).subscribe(() => {
+        this.tables = this.tables.filter(t => t.table_id !== id);
+      });
+    }
+  }
+}

--- a/src/app/pages/tickets/add-ticket/add-ticket.component.html
+++ b/src/app/pages/tickets/add-ticket/add-ticket.component.html
@@ -1,0 +1,36 @@
+<div class="form-container">
+  <h2>{{ isEdit ? 'Editar Ticket' : 'Crear Ticket' }}</h2>
+
+  <form [formGroup]="form" (ngSubmit)="submit()">
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>ID Orden</mat-label>
+      <input matInput type="number" formControlName="order_id">
+      <mat-error *ngIf="form.get('order_id')?.invalid">Requerido</mat-error>
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Total</mat-label>
+      <input matInput type="number" formControlName="total">
+      <mat-error *ngIf="form.get('total')?.invalid">Requerido</mat-error>
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Método de pago</mat-label>
+      <mat-select formControlName="payment_method">
+        <mat-option *ngFor="let pm of paymentMethods" [value]="pm.value">{{ pm.viewValue }}</mat-option>
+      </mat-select>
+      <mat-error *ngIf="form.get('payment_method')?.invalid">Requerido</mat-error>
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Fecha</mat-label>
+      <input matInput formControlName="issued_at">
+      <mat-error *ngIf="form.get('issued_at')?.invalid">Requerido</mat-error>
+    </mat-form-field>
+
+    <div class="actions">
+      <button mat-raised-button color="primary" type="submit">{{ isEdit ? 'Actualizar' : 'Crear' }}</button>
+      <button mat-raised-button color="warn" routerLink="/tickets/table" type="button">Cancelar</button>
+    </div>
+  </form>
+</div>

--- a/src/app/pages/tickets/add-ticket/add-ticket.component.scss
+++ b/src/app/pages/tickets/add-ticket/add-ticket.component.scss
@@ -1,0 +1,19 @@
+.form-container {
+  max-width: 600px;
+  margin: 2rem auto;
+  padding: 2rem;
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+}
+
+.full-width {
+  width: 100%;
+  margin-bottom: 1rem;
+}
+
+.actions {
+  display: flex;
+  gap: 1rem;
+  margin-top: 1.5rem;
+}

--- a/src/app/pages/tickets/add-ticket/add-ticket.component.spec.ts
+++ b/src/app/pages/tickets/add-ticket/add-ticket.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { AddTicketComponent } from './add-ticket.component';
+
+describe('AddTicketComponent', () => {
+  let component: AddTicketComponent;
+  let fixture: ComponentFixture<AddTicketComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [AddTicketComponent, HttpClientTestingModule, RouterTestingModule]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AddTicketComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/pages/tickets/add-ticket/add-ticket.component.ts
+++ b/src/app/pages/tickets/add-ticket/add-ticket.component.ts
@@ -1,0 +1,69 @@
+import { Component, OnInit } from '@angular/core';
+import { FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
+import { ActivatedRoute, Router } from '@angular/router';
+import { MaterialModule } from '../../../material.module';
+import { TicketService } from '../../../services/ticket.service';
+
+@Component({
+  selector: 'app-add-ticket',
+  standalone: true,
+  imports: [MaterialModule, ReactiveFormsModule],
+  templateUrl: './add-ticket.component.html',
+  styleUrl: './add-ticket.component.scss'
+})
+export class AddTicketComponent implements OnInit {
+  form: FormGroup;
+  isEdit = false;
+  ticketId: number | null = null;
+  paymentMethods = [
+    { value: 'cash', viewValue: 'Efectivo' },
+    { value: 'card', viewValue: 'Tarjeta' },
+    { value: 'qr', viewValue: 'QR' },
+    { value: 'account_credit', viewValue: 'Crédito en cuenta' }
+  ];
+
+  constructor(
+    private fb: FormBuilder,
+    private ticketService: TicketService,
+    private route: ActivatedRoute,
+    private router: Router
+  ) {
+    this.form = this.fb.group({
+      order_id: ['', Validators.required],
+      total: [0, [Validators.required, Validators.min(0)]],
+      payment_method: ['cash', Validators.required],
+      issued_at: ['', Validators.required]
+    });
+  }
+
+  ngOnInit(): void {
+    this.route.params.subscribe(params => {
+      if (params['id']) {
+        this.isEdit = true;
+        this.ticketId = +params['id'];
+        this.ticketService.getById(this.ticketId).subscribe(ticket => {
+          this.form.patchValue(ticket);
+        });
+      }
+    });
+  }
+
+  submit(): void {
+    if (this.form.invalid) {
+      return;
+    }
+    const data = this.form.value;
+
+    if (this.isEdit && this.ticketId) {
+      this.ticketService.update(this.ticketId, data).subscribe(() => {
+        alert('Ticket actualizado');
+        this.router.navigate(['/tickets/table']);
+      });
+    } else {
+      this.ticketService.create(data).subscribe(() => {
+        alert('Ticket creado');
+        this.router.navigate(['/tickets/table']);
+      });
+    }
+  }
+}

--- a/src/app/pages/tickets/table-tickets/table-tickets.component.html
+++ b/src/app/pages/tickets/table-tickets/table-tickets.component.html
@@ -1,0 +1,50 @@
+@if (!isLoading) {
+  <app-dynamic-filter [columns]="displayedColumns" [data]="tickets" (filteredData)="tickets = $event"></app-dynamic-filter>
+  <div class="table-container">
+    <table mat-table [dataSource]="tickets" class="mat-elevation-z8">
+      <ng-container matColumnDef="ticket_id">
+        <th mat-header-cell *matHeaderCellDef> ID </th>
+        <td mat-cell *matCellDef="let ticket">{{ ticket.ticket_id }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="order_id">
+        <th mat-header-cell *matHeaderCellDef> Orden </th>
+        <td mat-cell *matCellDef="let ticket">{{ ticket.order_id }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="total">
+        <th mat-header-cell *matHeaderCellDef> Total </th>
+        <td mat-cell *matCellDef="let ticket">{{ ticket.total }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="payment_method">
+        <th mat-header-cell *matHeaderCellDef> Pago </th>
+        <td mat-cell *matCellDef="let ticket">{{ ticket.payment_method }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="issued_at">
+        <th mat-header-cell *matHeaderCellDef> Fecha </th>
+        <td mat-cell *matCellDef="let ticket">{{ ticket.issued_at }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="actions">
+        <th mat-header-cell *matHeaderCellDef> Acciones </th>
+        <td mat-cell *matCellDef="let ticket">
+          <button mat-icon-button color="primary" [routerLink]="['/tickets/edit', ticket.ticket_id]"><mat-icon>edit</mat-icon></button>
+          <button mat-icon-button color="warn" (click)="delete(ticket.ticket_id)"><mat-icon>delete</mat-icon></button>
+        </td>
+      </ng-container>
+
+      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+    </table>
+  </div>
+}
+@else {
+  <ng-template #loading>
+    <div class="loading">
+      <mat-spinner></mat-spinner>
+      <p>Cargando tickets...</p>
+    </div>
+  </ng-template>
+}

--- a/src/app/pages/tickets/table-tickets/table-tickets.component.scss
+++ b/src/app/pages/tickets/table-tickets/table-tickets.component.scss
@@ -1,0 +1,20 @@
+.table-container {
+  max-width: 1000px;
+  margin: 20px auto;
+  padding: 15px;
+}
+
+mat-header-cell {
+  font-weight: bold;
+}
+
+mat-icon {
+  vertical-align: middle;
+}
+
+.loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-top: 50px;
+}

--- a/src/app/pages/tickets/table-tickets/table-tickets.component.spec.ts
+++ b/src/app/pages/tickets/table-tickets/table-tickets.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { TableTicketsComponent } from './table-tickets.component';
+
+describe('TableTicketsComponent', () => {
+  let component: TableTicketsComponent;
+  let fixture: ComponentFixture<TableTicketsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TableTicketsComponent, HttpClientTestingModule, RouterTestingModule]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TableTicketsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/pages/tickets/table-tickets/table-tickets.component.ts
+++ b/src/app/pages/tickets/table-tickets/table-tickets.component.ts
@@ -1,0 +1,46 @@
+import { Component } from '@angular/core';
+import { Ticket } from '../../../models/Ticket.model';
+import { TicketService } from '../../../services/ticket.service';
+import { MaterialModule } from '../../../material.module';
+import { DynamicFilterComponent } from '../../../shared/dynamic-filter/dynamic-filter.component';
+import { RouterModule } from '@angular/router';
+
+@Component({
+  selector: 'app-table-tickets',
+  standalone: true,
+  imports: [MaterialModule, DynamicFilterComponent, RouterModule],
+  templateUrl: './table-tickets.component.html',
+  styleUrl: './table-tickets.component.scss'
+})
+export class TableTicketsComponent {
+  displayedColumns: string[] = ['ticket_id', 'order_id', 'total', 'payment_method', 'issued_at', 'actions'];
+  tickets: Ticket[] = [];
+  isLoading = true;
+
+  constructor(private ticketService: TicketService) {}
+
+  ngOnInit(): void {
+    this.loadTickets();
+  }
+
+  loadTickets(): void {
+    this.ticketService.getAll().subscribe({
+      next: data => {
+        this.tickets = data;
+        this.isLoading = false;
+      },
+      error: err => {
+        console.error('Error fetching tickets', err);
+        this.isLoading = false;
+      }
+    });
+  }
+
+  delete(id: number): void {
+    if (confirm('¿Eliminar ticket?')) {
+      this.ticketService.delete(id).subscribe(() => {
+        this.tickets = this.tickets.filter(t => t.ticket_id !== id);
+      });
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add activity log management pages
- support printer configuration CRUD
- manage restaurant tables and tickets

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_689e5cc17460832eba8aadf0b5591429